### PR TITLE
Change fenced code block to non-greedy regexp

### DIFF
--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -2583,7 +2583,7 @@ MarkdownExtra_Parser.prototype.doFencedCodeBlocks = function(text) {
         '('                      +
             '(?:'                +
                 '(?!\\1[ ]*\\n)' + // Not a closing marker.
-                '[\\s\\S]*\\n+'  +
+                '[\\s\\S]*?\\n+' +
             ')'                  +
         ')'                      +
         // Closing marker.


### PR DESCRIPTION
Fenced code block was greedy by default, so if you have multiple fenced code block, everything in between will be rendered as part of it. Changing the regexp to a non-greedy one fixed the problem.
