### PR TITLE
Fix defList regex to prevent unneccesary backtracking

### DIFF
--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -2443,7 +2443,7 @@ MarkdownExtra_Parser.prototype.doDefLists = function(text) {
         '('                       + // $1 = whole list
           '('                     + // $2
             '[ ]{0,' + less_than_tab + '}' +
-            '((?:.*\\S.*\\n)+)'   + // $3 = defined term
+            '((?:[ \\t]*\\S.*\\n)+)' + // $3 = defined term
             '\\n?'                +
             '[ ]{0,' + less_than_tab + '}:[ ]+' + // colon starting definition
           ')'                     +

--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -2444,6 +2444,11 @@ MarkdownExtra_Parser.prototype.doDefLists = function(text) {
           '('                     + // $2
             '[ ]{0,' + less_than_tab + '}' +
             '((?:[ \\t]*\\S.*\\n)+)' + // $3 = defined term
+                                       // [porting note] Original regex from PHP is
+                                       // (?>.*\S.*\n), which matches a line with at
+                                       // least one non-space character. Change the
+                                       // first .* to [ \t]* stops unneccessary
+                                       // backtracking hence improves performance
             '\\n?'                +
             '[ ]{0,' + less_than_tab + '}:[ ]+' + // colon starting definition
           ')'                     +


### PR DESCRIPTION
The original PHP regex is trying to match a line with at least one non-space character, and it uses `((?>.*\S.*\n)+)` which does not backtrack.

The javascript version do backtrack, makes it extremely slow in certain situation.

Replacing it with `((?:[ \\t]*\\S.*\\n)+)` so that no backtracking is needed, and works just like the PHP code.

Code to reproduce problem:

``` javascript
var md = require('./js-markdown-extra');
var text='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n';
var output = md.Markdown(text);
```
