### PR TITLE
Do not consume the trailing newlines in deflist regex

### DIFF
--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -2451,16 +2451,18 @@ MarkdownExtra_Parser.prototype.doDefLists = function(text) {
           '('                     + // $4
               '(?=\\0x03)'        + // \z
             '|'                   +
-              '\\n{2,}'           +
-              '(?=\\S)'           +
-              '(?!'               + // Negative lookahead for another term
-                '[ ]{0,' + less_than_tab + '}' +
-                '(?:\\S.*\\n )+?' + // defined term
-                '\\n?'            +
-                '[ ]{0,' + less_than_tab + '}:[ ]+' + // colon starting definition
-              ')'                 +
-              '(?!'               + // Negative lookahead for another definition
-                '[ ]{0,' + less_than_tab + '}:[ ]+' + // colon starting definition
+              '(?='               +
+                '\\n{2,}'         +
+                '(?=\\S)'         +
+                '(?!'             + // Negative lookahead for another term
+                  '[ ]{0,' + less_than_tab + '}' +
+                  '(?:\\S.*\\n )+?' + // defined term
+                  '\\n?'          +
+                  '[ ]{0,' + less_than_tab + '}:[ ]+' + // colon starting definition
+                ')'               +
+                '(?!'             + // Negative lookahead for another definition
+                  '[ ]{0,' + less_than_tab + '}:[ ]+' + // colon starting definition
+                ')'               +
               ')'                 +
           ')'                     +
         ')'                       +
@@ -2532,7 +2534,7 @@ MarkdownExtra_Parser.prototype.processDefListItems = function(list_str) {
             '[:][ ]+'                      + // definition mark (colon)
         ')'                                +
         '([\\s\\S]+?)'                     + // definition text = $3
-        '(?=\\n+'                          + // stop at next definition mark,
+        '(?=\\n*'                          + // stop at next definition mark,
             '(?:'                          + // next term or end of text
                 '[ ]{0,' + less_than_tab + '}[:][ ]|' +
                 '<dt>|\\x03'               + // \z

--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -2541,7 +2541,8 @@ MarkdownExtra_Parser.prototype.processDefListItems = function(list_str) {
                                              // following line from \n+ to \n*.
         '(?=\\n*'                          + // stop at next definition mark,
             '(?:'                          + // next term or end of text
-                '[ ]{0,' + less_than_tab + '}[:][ ]|' +
+                '\\n[ ]{0,' + less_than_tab + '}[:][ ]|' + // [porting note] do not match
+                                                           // colon in the middle of a line
                 '<dt>|\\x03'               + // \z
             ')'                            +
         ')',

--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -2451,7 +2451,9 @@ MarkdownExtra_Parser.prototype.doDefLists = function(text) {
           '('                     + // $4
               '(?=\\0x03)'        + // \z
             '|'                   +
-              '(?='               +
+              '(?='               + // [porting note] Our regex will consume leading
+                                    // newline characters so we will leave the newlines
+                                    // here for the next definition
                 '\\n{2,}'         +
                 '(?=\\S)'         +
                 '(?!'             + // Negative lookahead for another term
@@ -2534,6 +2536,9 @@ MarkdownExtra_Parser.prototype.processDefListItems = function(list_str) {
             '[:][ ]+'                      + // definition mark (colon)
         ')'                                +
         '([\\s\\S]+?)'                     + // definition text = $3
+                                             // [porting note] Maybe no trailing
+                                             // newlines in our version, changed the
+                                             // following line from \n+ to \n*.
         '(?=\\n*'                          + // stop at next definition mark,
             '(?:'                          + // next term or end of text
                 '[ ]{0,' + less_than_tab + '}[:][ ]|' +


### PR DESCRIPTION
Since there is no lookbehind is javascript regex, the regex in deflist matches both preceding and trailing newline characters, causing consecutive deflist to fail.

Fixed this by excluding newline characters from the regex so that the next definition will be matched.

Please note that this process is different from the PHP version and I don't know if you would want to merge this.

Markdown to reproduce problem:

```
term1
: def1

term2
: def2

term3
: def3

term4
: def4
: def5
```

Thanks.
