### PR TITLE
CRLF line endings fix

### DIFF
--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -287,7 +287,7 @@ Markdown_Parser.prototype.transform = function(text) {
 
     // Standardize line endings:
     //   DOS to Unix and Mac to Unix
-    text = text.replace(/\r\n?/, "\n", text);
+    text = text.replace(/\r\n?/g, "\n", text);
 
     // Make sure $text ends with a couple of newlines:
     text += "\n\n";

--- a/run-unit-tests.html
+++ b/run-unit-tests.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
+    <script src="js-markdown-extra.js"></script>
+    <script src="http://code.jquery.com/qunit/qunit-1.11.0.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.11.0.css" type="text/css" media="screen" />
+</head>
+<body>
+<h1 id="qunit-header">js-markdown-extra</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+
+<script src="unit-tests/crlf.js"></script>
+
+</body>
+</html>

--- a/unit-tests/crlf.js
+++ b/unit-tests/crlf.js
@@ -1,0 +1,56 @@
+module( "CRLF Unit tests" );
+
+// Used - http://www.howtocreate.co.uk/tutorials/jsexamples/syntax/prepareInline.html
+var expected = '<h1>Syntax Cheatsheet<\/h1>\n\n<h2>PHRASE EMPHASIS<\/h2>\n\n<p><em>italic<\/em>   <strong>bold<\/strong>\n<em>italic<\/em>   <strong>bold<\/strong><\/p>\n\n<h1>Header 1<\/h1>\n\n<h2>Header 2<\/h2>\n\n<h1>Header 1<\/h1>\n\n<h2>Header 2<\/h2>\n\n<h6>Header 6<\/h6>\n';
+
+/* 
+ * Test 01 - LF
+ */
+QUnit.test( "01 - LF", function() {
+	
+	var input =
+		'Syntax Cheatsheet' + "\n" +
+		'========================================' + "\n" +
+		'PHRASE EMPHASIS' + "\n" +
+		'---------------' + "\n" +
+		'*italic*   **bold**' + "\n" +  
+		'_italic_   __bold__' + "\n" +
+		'Header 1' + "\n" +
+		'========' + "\n" +
+		'Header 2' + "\n" +
+		'--------' + "\n" +
+		'# Header 1 #' + "\n" +
+		'## Header 2 ##' + "\n" +
+		'###### Header 6' + "\n";	
+	
+	var result = Markdown(input);
+	console.log(result);
+	
+    QUnit.assert.equal(result, expected, "Unexpected result!");
+});
+
+/* 
+ * Test 02 - CRLF
+ */
+QUnit.test( "02 - CRLF", function() {
+	
+	var input =
+		'Syntax Cheatsheet' + "\r\n" +
+		'========================================' + "\r\n" +
+		'PHRASE EMPHASIS' + "\r\n" +
+		'---------------' + "\r\n" +
+		'*italic*   **bold**' + "\r\n" +  
+		'_italic_   __bold__' + "\r\n" +
+		'Header 1' + "\r\n" +
+		'========' + "\r\n" +
+		'Header 2' + "\r\n" +
+		'--------' + "\r\n" +
+		'# Header 1 #' + "\r\n" +
+		'## Header 2 ##' + "\r\n" +
+		'###### Header 6' + "\r\n";	
+	
+	var result = Markdown(input);
+	console.log(result);
+	
+    QUnit.assert.equal(result, expected, "Unexpected result!");
+});

--- a/unit-tests/crlf.js
+++ b/unit-tests/crlf.js
@@ -24,9 +24,7 @@ QUnit.test( "01 - LF", function() {
 		'###### Header 6' + "\n";	
 	
 	var result = Markdown(input);
-	console.log(result);
-	
-    QUnit.assert.equal(result, expected, "Unexpected result!");
+	QUnit.assert.equal(result, expected);
 });
 
 /* 
@@ -50,7 +48,5 @@ QUnit.test( "02 - CRLF", function() {
 		'###### Header 6' + "\r\n";	
 	
 	var result = Markdown(input);
-	console.log(result);
-	
-    QUnit.assert.equal(result, expected, "Unexpected result!");
+	QUnit.assert.equal(result, expected);
 });


### PR DESCRIPTION
Hi,
I recently had an issue converting markdown files explicitly saved in Windows Format CR+LF format. 
This tiny fix seems to have fixed that problem ;).

I additionally added some unit tests based on QUnit.
