### PR TITLE
A simple check to kill the "`" check endless loop

### DIFF
--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -1948,10 +1948,14 @@ MarkdownExtra_Parser.prototype._hashHTMLBlocks_inMarkdown = function(text, inden
         //
         // Check for: Code span marker
         //
-	if (tag.charAt(0) == "`" && text.replace(/[^`]/g, "").length != 0) {
+	if (tag.charAt(0) == "`") {
             // Find corresponding end marker.
             tag_re = this._php_preg_quote(tag);
-            if(matches = text.match(new RegExp('^(.+?|\\n[^\\n])*?[^`]' + tag_re + '[^`]'))) {
+
+	    if (
+                tag.substr(1).indexOf('`') != -1 && // [portiong note] To avoid JS's RegExp infinity loop.
+                (matches = text.match(new RegExp('^(.+?|\\n[^\\n])*?[^`]' + tag_re + '[^`]')))
+            ) {
                 // End marker found: pass text unchanged until marker.
                 parsed += tag + matches[0];
                 text = text.substr(matches[0].length);

--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -1948,7 +1948,7 @@ MarkdownExtra_Parser.prototype._hashHTMLBlocks_inMarkdown = function(text, inden
         //
         // Check for: Code span marker
         //
-        if (tag.charAt(0) == "`") {
+	if (tag.charAt(0) == "`" && text.replace(/[^`]/g, "").length != 0) {
             // Find corresponding end marker.
             tag_re = this._php_preg_quote(tag);
             if(matches = text.match(new RegExp('^(.+?|\\n[^\\n])*?[^`]' + tag_re + '[^`]'))) {


### PR DESCRIPTION
This patch simply checks for remaining "`" char in the "text" variable. If there are none, then the inner conditional that looks for a match is skipped. This prevents the conditional from being entered in cases where an endless loop could occur.

It makes the code below succeed where it would otherwise fail.

``` javascript
Markdown("##Usage\n###Simple, `standard, awesome\n~~~\njQuery('some_selector').meltdown();\n~~~\n");
```
