### PR TITLE
Adding conditional wraps around two regexes in doAnchors, this should pr...

### DIFF
--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -674,8 +674,8 @@ Markdown_Parser.prototype.doAnchors = function(text) {
 	// be able to find a match. If we don't do this here we can get caught in
 	// a situation where backtracking grows exponentially.
 	// This helps us keep the same regex as the upstream PHP impl, but still be safe/fast
-	var cheatText = text.replace(/[^\[^\]\n]/gm, '');
-	if ((cheatText.indexOf('[][]') !== -1) || (cheatText.indexOf('[]\n[]') !== -1)) {
+    var cheatText = text.replace(/[^\[^\]^\n^\s]/gm, '');
+    if ((cheatText.indexOf("[][]") !== -1) || (cheatText.indexOf("[] []") !== -1) || (cheatText.indexOf("[]\n[]") !== -1)) {
 		text = text.replace(new RegExp(
 			'('               + // wrap whole match in $1
 				'\\['           +

--- a/js-markdown-extra.js
+++ b/js-markdown-extra.js
@@ -701,7 +701,7 @@ Markdown_Parser.prototype.doAnchors = function(text) {
 	// be able to find a match. If we don't do this here we can get caught in
 	// a situation where backtracking grows exponentially.
 	// This helps us keep the same regex as the upstream PHP impl, but still be safe/fast
-	cheatText = text.replace(/[^\]^\[^\(^\)]/gm, '');
+    cheatText = text.replace(/[^\(^\)^\[^\]^\s]/gm, '').replace(/\(.*?\)/,'()');
 	if ((cheatText.indexOf("[]()") !== -1) || (cheatText.indexOf("[](\"\")") !== -1)) {
 		text = text.replace(new RegExp(
 			'('               + // wrap whole match in $1


### PR DESCRIPTION
This patch wraps two regular replace()s in a safety check that should prevent the run away callback scenarios from occurring and not affect the replace().

Wrapping the regex in a safety check aslo keeps the regex code untouched, so it can be compared easliy with the "upstream" PHP impl.

To test before and after try:

``` javascript

    var start = new Date().getTime();
    md.Markdown(str);
    var elapsed = new Date().getTime() - start;                                                                                                                                 
    console.log("run #" + i + " took: " + elapsed + "ms");
```
